### PR TITLE
Manual dotfiles

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,3 +27,8 @@ for file in $files; do
     echo "Creating symlink ~/.$file"
     ln -s $dir/"$file" ~/.$file
 done
+
+echo Please install the following files manually:
+for f in $manual_files; do
+    echo "* $f"
+done


### PR DESCRIPTION
Printing info about manual files - these are not placed as ~/.file, but instead
have to be installed (symlinked) by the user manually somewehere.

Previously, only a variable existed to define such files, but nothing was done with it.
