### PR TITLE
Cleanup bash

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -25,8 +25,6 @@ alias gpp='git push && git push diskstation'
 # Taken from https://stackoverflow.com/a/1571525
 alias git-root='cd $(git rev-parse --show-toplevel)'
 
-PATH="/Users/marius/.conscript/bin:$PATH"
-
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
 # Added by GDK bootstrap

--- a/bashrc
+++ b/bashrc
@@ -26,12 +26,3 @@ alias gpp='git push && git push diskstation'
 alias git-root='cd $(git rev-parse --show-toplevel)'
 
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
-
-# Added by GDK bootstrap
-export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:${PKG_CONFIG_PATH}"
-
-# Added by GDK bootstrap
-export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl@1.1 --with-readline-dir=/usr/local/opt/readline"
-
-# Added by GDK bootstrap
-source /Users/marius/.asdf/asdf.sh

--- a/bashrc
+++ b/bashrc
@@ -6,7 +6,9 @@
 # and are not inherited by subshells. These most particularly include alias
 # and function definitions.
 
+################################################################################
 # Bash completions
+################################################################################
 
 # Source all homebrew bash completion files
 if type brew &>/dev/null; then
@@ -20,8 +22,14 @@ if type brew &>/dev/null; then
   fi
 fi
 
+# fzf initialization includes bash completions, so we need to include it here
+# rather than in profile:
+[ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
+
+################################################################################
 # Function definitions
+################################################################################
 
 function ts   # ts x y sets screen width to x chars and y lines
 {
@@ -66,16 +74,10 @@ git_prompt() {
     #echo "\[${GREEN}\]Green: ${DATE} \[${RED}\]Hello world \[${NC}\]"
 }
 
-# Fancy git prompt (uses the above two functions)
-# Import color definitions if they exist
-if [ -f $HOME/.ansi_colors ]; then
-    . $HOME/.ansi_colors
-fi
-PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(git_prompt) \$ "'
-
-
-
+################################################################################
 # Alias definitions
+################################################################################
+
 alias ls='gls --color=auto'
 alias ll='ls -l'
 alias la='ls -a'
@@ -93,4 +95,15 @@ alias gpp='git push && git push diskstation'
 # Taken from https://stackoverflow.com/a/1571525
 alias git-root='cd $(git rev-parse --show-toplevel)'
 
-[ -f ~/.fzf.bash ] && source ~/.fzf.bash
+
+
+################################################################################
+# Other (sub)shell specific configuration
+################################################################################
+
+# Fancy git prompt (uses the above two functions)
+# Import color definitions if they exist
+if [ -f $HOME/.ansi_colors ]; then
+    . $HOME/.ansi_colors
+fi
+PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(git_prompt) \$ "'

--- a/bashrc
+++ b/bashrc
@@ -1,4 +1,12 @@
-# Function definition
+# This file should be symlinked as ~/.bashrc. Its contents are executed whenever
+# a new shell is launched (both login and non-login shells, by explicitly
+# calling it from .profile). See also the documentation at the top of profile.
+#
+# This file should contain any definitions that live only for the current shell
+# and are not inherited by subshells. These most particularly include alias
+# and function definitions.
+
+# Function definitions
 
 function ts   # ts x y sets screen width to x chars and y lines
 {

--- a/bashrc
+++ b/bashrc
@@ -6,6 +6,21 @@
 # and are not inherited by subshells. These most particularly include alias
 # and function definitions.
 
+# Bash completions
+
+# Source all homebrew bash completion files
+if type brew &>/dev/null; then
+  HOMEBREW_PREFIX="$(brew --prefix)"
+  if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
+    source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
+  else
+    for COMPLETION in "${HOMEBREW_PREFIX}/etc/bash_completion.d/"*; do
+      [[ -r "$COMPLETION" ]] && source "$COMPLETION"
+    done
+  fi
+fi
+
+
 # Function definitions
 
 function ts   # ts x y sets screen width to x chars and y lines
@@ -14,6 +29,51 @@ function ts   # ts x y sets screen width to x chars and y lines
     echo -ne "\033[8;$2;$1t"
   fi
 }
+
+# Functions for git prompt
+function minutes_since_last_commit {
+    now=`date +%s`
+    last_commit="$(git log --pretty=format:'%at' -1 2>/dev/null)"
+    if [ -n "$last_commit" ]; then
+        seconds_since_last_commit=$((now-last_commit))
+        minutes_since_last_commit=$((seconds_since_last_commit/60))
+        echo $minutes_since_last_commit
+    else
+        echo 0
+    fi
+}
+
+git_prompt() {
+    local DATE=`date`
+    local GITDIR=`__gitdir`
+    if [ -n "$GITDIR" ]; then
+
+        local MINUTES_SINCE_LAST_COMMIT=`minutes_since_last_commit`
+
+        if [ "$MINUTES_SINCE_LAST_COMMIT" -gt 30 ]; then
+            local COLOR=${RED}
+        elif [ "$MINUTES_SINCE_LAST_COMMIT" -gt 10 ]; then
+            local COLOR=${YELLOW}
+        else
+            local COLOR=${GREEN}
+        fi
+
+        BRANCH=`__git_ps1 '%s'`
+        MINUTES="\[${COLOR}\]${MINUTES_SINCE_LAST_COMMIT}m\[${NC}\]"
+        GIT_PROMPT=" (${BRANCH}|${MINUTES})"
+        echo "$GIT_PROMPT"
+    fi
+    #echo "\[${GREEN}\]Green: ${DATE} \[${RED}\]Hello world \[${NC}\]"
+}
+
+# Fancy git prompt (uses the above two functions)
+# Import color definitions if they exist
+if [ -f $HOME/.ansi_colors ]; then
+    . $HOME/.ansi_colors
+fi
+PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(git_prompt) \$ "'
+
+
 
 # Alias definitions
 alias ls='gls --color=auto'

--- a/profile
+++ b/profile
@@ -23,11 +23,6 @@ export LC_ALL=en_US.UTF-8
 # See https://apple.stackexchange.com/a/371998
 export BASH_SILENCE_DEPRECATION_WARNING=1
 
-# Run .bashrc if it exists
-if [ -f $HOME/.bashrc ]; then
-  . $HOME/.bashrc
-fi
-
 # Add (or move) Homebrew prefix to the beginning of the PATH
 CLEANPATH=`echo $PATH | sed -E 's#/usr/local/bin:?##'`
 export PATH=/usr/local/bin:/usr/local/sbin:$PATH
@@ -42,3 +37,8 @@ export PATH="$HOME/.cargo/bin:$PATH"
 export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:${PKG_CONFIG_PATH}"
 export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl@1.1 --with-readline-dir=/usr/local/opt/readline"
 source /Users/marius/.asdf/asdf.sh
+
+# Run .bashrc if it exists
+if [ -f $HOME/.bashrc ]; then
+  . $HOME/.bashrc
+fi

--- a/profile
+++ b/profile
@@ -73,11 +73,6 @@ git_prompt() {
 
 export PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(git_prompt) \$ "'
 
-# Setting PATH for Python 2.7
-# The orginal version is saved in .profile.pysave
-PATH="/Library/Frameworks/Python.framework/Versions/2.7/bin:${PATH}"
-export PATH
-
 # More memory for sbt
 export SBT_OPTS="-XX:MaxPermSize=256M"
 

--- a/profile
+++ b/profile
@@ -77,3 +77,8 @@ export PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(
 
 # Path config for Rust installation
 export PATH="$HOME/.cargo/bin:$PATH"
+
+# Added by GDK bootstrap
+export PKG_CONFIG_PATH="/usr/local/opt/icu4c/lib/pkgconfig:${PKG_CONFIG_PATH}"
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl@1.1 --with-readline-dir=/usr/local/opt/readline"
+source /Users/marius/.asdf/asdf.sh

--- a/profile
+++ b/profile
@@ -28,67 +28,12 @@ if [ -f $HOME/.bashrc ]; then
   . $HOME/.bashrc
 fi
 
-# Import color definitions if they exist
-if [ -f $HOME/.ansi_colors ]; then
-    . $HOME/.ansi_colors
-fi
-
 # Add (or move) Homebrew prefix to the beginning of the PATH
 CLEANPATH=`echo $PATH | sed -E 's#/usr/local/bin:?##'`
 export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 
 # Add personal bin directory to beginning of path.
 export PATH=$HOME/bin:$PATH
-
-## source all homebrew bash completion files
-if type brew &>/dev/null; then
-  HOMEBREW_PREFIX="$(brew --prefix)"
-  if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
-    source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
-  else
-    for COMPLETION in "${HOMEBREW_PREFIX}/etc/bash_completion.d/"*; do
-      [[ -r "$COMPLETION" ]] && source "$COMPLETION"
-    done
-  fi
-fi
-
-# Functions for git prompt
-function minutes_since_last_commit {
-    now=`date +%s`
-    last_commit="$(git log --pretty=format:'%at' -1 2>/dev/null)"
-    if [ -n "$last_commit" ]; then
-        seconds_since_last_commit=$((now-last_commit))
-        minutes_since_last_commit=$((seconds_since_last_commit/60))
-        echo $minutes_since_last_commit
-    else
-        echo 0
-    fi
-}
-
-git_prompt() {
-    local DATE=`date`
-    local GITDIR=`__gitdir`
-    if [ -n "$GITDIR" ]; then
-
-        local MINUTES_SINCE_LAST_COMMIT=`minutes_since_last_commit`
-
-        if [ "$MINUTES_SINCE_LAST_COMMIT" -gt 30 ]; then
-            local COLOR=${RED}
-        elif [ "$MINUTES_SINCE_LAST_COMMIT" -gt 10 ]; then
-            local COLOR=${YELLOW}
-        else
-            local COLOR=${GREEN}
-        fi
-
-        BRANCH=`__git_ps1 '%s'`
-        MINUTES="\[${COLOR}\]${MINUTES_SINCE_LAST_COMMIT}m\[${NC}\]"
-        GIT_PROMPT=" (${BRANCH}|${MINUTES})"
-        echo "$GIT_PROMPT"
-    fi
-    #echo "\[${GREEN}\]Green: ${DATE} \[${RED}\]Hello world \[${NC}\]"
-}
-
-export PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(git_prompt) \$ "'
 
 # Path config for Rust installation
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/profile
+++ b/profile
@@ -1,3 +1,18 @@
+# This file should be symlinked as ~/.profile (or perhaps ~/.bash_profile).
+# It is executed each time a login shell is opened, but not when a non-login
+# shell is opened (see https://apple.stackexchange.com/a/51038 for details and
+# https://unix.stackexchange.com/a/46856 for the difference between different
+# shell invocations.
+#
+# Note that default behavior in Mac OS is to launch a login shell for each new
+# terminal window or tab (but this can be changed in Terminal.app's settings).
+#
+# Since the contents of this file are only executed for login shells, any
+# commands or definitions whose scope is the current shell only, most
+# particularly alias or function definitions, should not go here but to .bashrc
+# instead. On the other hand, variable exports are fine here, as these will be
+# inherited by subshells.
+
 # vim:ft=sh
 export EDITOR="/usr/bin/vim"
 

--- a/profile
+++ b/profile
@@ -75,8 +75,5 @@ git_prompt() {
 
 export PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(git_prompt) \$ "'
 
-# More memory for sbt
-export SBT_OPTS="-XX:MaxPermSize=256M"
-
 # Path config for Rust installation
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/profile
+++ b/profile
@@ -16,7 +16,7 @@ if [ -f $HOME/.ansi_colors ]; then
     . $HOME/.ansi_colors
 fi
 
-# Move /usr/local/bin to beginning of path
+# Add (or move) Homebrew prefix to the beginning of the PATH
 CLEANPATH=`echo $PATH | sed -E 's#/usr/local/bin:?##'`
 export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 

--- a/profile
+++ b/profile
@@ -78,4 +78,5 @@ export PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(
 # More memory for sbt
 export SBT_OPTS="-XX:MaxPermSize=256M"
 
+# Path config for Rust installation
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/profile
+++ b/profile
@@ -1,6 +1,8 @@
 # vim:ft=sh
 export EDITOR="/usr/bin/vim"
-export LANG=en_US.UTF-8
+
+# Locale settings to enable proper use of Unicode/UTF-8 throughout
+export LC_ALL=en_US.UTF-8
 
 # Disable OS X Catalina warning about zsh being the default shell
 # See https://apple.stackexchange.com/a/371998
@@ -75,9 +77,5 @@ export PROMPT_COMMAND='PS1="\[${LIGHTGREEN}\]\u@\h\[${LIGHTBLUE}\] \W\[${NC}\]$(
 
 # More memory for sbt
 export SBT_OPTS="-XX:MaxPermSize=256M"
-
-# Fix OS X locale (otherwise python locale won't work well)
-# See http://fruitfulerrors.blogspot.hu/2011/01/osx-106-lcctype.html
-export LC_CTYPE="en_US.utf-8"
 
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/profile
+++ b/profile
@@ -6,10 +6,6 @@ export LANG=en_US.UTF-8
 # See https://apple.stackexchange.com/a/371998
 export BASH_SILENCE_DEPRECATION_WARNING=1
 
-if [ -n "$PSOUT" ]; then
-  export DISPLAY=":0.0"
-fi
-
 # Java
 # See http://stackoverflow.com/a/6588410
 export JAVA_HOME=`/usr/libexec/java_home -v 1.8`

--- a/profile
+++ b/profile
@@ -6,10 +6,6 @@ export LANG=en_US.UTF-8
 # See https://apple.stackexchange.com/a/371998
 export BASH_SILENCE_DEPRECATION_WARNING=1
 
-# Java
-# See http://stackoverflow.com/a/6588410
-export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
-
 # Run .bashrc if it exists
 if [ -f $HOME/.bashrc ]; then
   . $HOME/.bashrc

--- a/profile
+++ b/profile
@@ -24,8 +24,15 @@ export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 export PATH=$HOME/bin:$PATH
 
 ## source all homebrew bash completion files
-if [ -f `brew --prefix`/etc/bash_completion ]; then
-    . `brew --prefix`/etc/bash_completion
+if type brew &>/dev/null; then
+  HOMEBREW_PREFIX="$(brew --prefix)"
+  if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
+    source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
+  else
+    for COMPLETION in "${HOMEBREW_PREFIX}/etc/bash_completion.d/"*; do
+      [[ -r "$COMPLETION" ]] && source "$COMPLETION"
+    done
+  fi
 fi
 
 # Functions for git prompt


### PR DESCRIPTION
In this PR I am doing both some long-needed cleanup, removing obsolete configuration entries, as well as restructuring after understanding better the difference between `.profile` and `.bashrc`. In particular, I had some configuration in `.profile` that is not inherited by subshells (any non-login shells). This included for example bash completions for git or the fancy git prompt. As a result, when opening a new bash from within an existing shell, these things would not work.

Now everything is in its proper place. The .profile file has shrunk down to basically environment variable definitions.

This cleanup work will also be useful in case I decide to migrate to a new shell such as fish or zsh.